### PR TITLE
Update ansible-operator version to get access to better logging

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.7.0
+FROM quay.io/operator-framework/ansible-operator:v0.10.0
 
 COPY roles/ ${HOME}/roles/
 COPY watches.yaml ${HOME}/watches.yaml

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -13,11 +13,8 @@ spec:
         name: game-server-operator
     spec:
       serviceAccountName: game-server-operator
-      volumes:
-      - name: ansible-operator
-        emptyDir: {}
       containers:
-        - name: game-server-operator
+        - name: operator
           # Replace this with the built image name
           image: docker.io/fabianvf/game-server-operator:latest
           imagePullPolicy: Always
@@ -35,16 +32,20 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "game-server-operator"
-        - name: ansible
-          image: docker.io/fabianvf/multitail
-          imagePullPolicy: Always
           volumeMounts:
-          - mountPath: /logs
-            name: ansible-operator
-            readOnly: True
+          - mountPath: /tmp/ansible-operator/runner
+            name: runner
+        - name: ansible
           command:
-          - multitail
-          - "--follow-all"
-          - "-Q" 
-          - "1"
-          - "/logs/*/*/*/*/*/artifacts/*/stdout"
+          - /usr/local/bin/ao-logs
+          - /tmp/ansible-operator/runner
+          - stdout
+          image: quay.io/operator-framework/ansible-operator:v0.10.0
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - mountPath: /tmp/ansible-operator/runner
+            name: runner
+            readOnly: true
+      volumes:
+        - name: runner
+          emptyDir: {}

--- a/deploy/operator.yaml.j2
+++ b/deploy/operator.yaml.j2
@@ -14,7 +14,7 @@ spec:
     spec:
       serviceAccountName: game-server-operator
       containers:
-        - name: game-server-operator
+        - name: operator
           # Replace this with the built image name
           image: "{{ image }}"
           imagePullPolicy: "{{ pull_policy|default('Always') }}"
@@ -29,3 +29,20 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "game-server-operator"
+          volumeMounts:
+          - mountPath: /tmp/ansible-operator/runner
+            name: runner
+        - name: ansible
+          command:
+          - /usr/local/bin/ao-logs
+          - /tmp/ansible-operator/runner
+          - stdout
+          image: quay.io/operator-framework/ansible-operator:v0.10.0
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - mountPath: /tmp/ansible-operator/runner
+            name: runner
+            readOnly: true
+      volumes:
+        - name: runner
+          emptyDir: {}

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - pods
   - services
+  - services/finalizers
   - endpoints
   - persistentvolumeclaims
   - events
@@ -26,6 +27,7 @@ rules:
   - apps
   resources:
   - deployments
+  - deployments/finalizers
   - daemonsets
   - replicasets
   - statefulsets
@@ -38,14 +40,6 @@ rules:
   verbs:
   - get
   - create
-- apiGroups:
-  - apps
-  resourceNames:
-  - game-server-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
 - apiGroups:
   - games.fabianism.us
   resources:


### PR DESCRIPTION
closes #6 

The logging stuff that's in current master should not have made it in, but I added a real version of it to the ansible-operator base image a while back, this PR will update us and make use of the new logging stuff.